### PR TITLE
Fixed sub-commands not working

### DIFF
--- a/src/main/java/me/axecy/saltcore/Main.java
+++ b/src/main/java/me/axecy/saltcore/Main.java
@@ -10,8 +10,8 @@ public class Main extends JavaPlugin {
     public void onEnable() {
         saveDefaultConfig();
         this.getCommand("spawn").setExecutor(new SpawnCommand(this));
-        this.getCommand("saltcore setspawn").setExecutor(new SetSpawnCommand(this));
-        this.getCommand("saltcore reload").setExecutor(new ReloadConfigCommand(this));
+        this.getCommand("saltcore-setspawn").setExecutor(new SetSpawnCommand(this));
+        this.getCommand("saltcore-reload").setExecutor(new ReloadConfigCommand(this));
         this.getCommand("rtp").setExecutor(new RTPCommand(this));
         this.getCommand("home").setExecutor(new HomeCommand(this));
         this.getCommand("sethome").setExecutor(new HomeCommand(this));

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,13 +9,13 @@ commands:
     description: Teleport player to spawn.
     aliases: [ hub, lobby ]
     permission: saltcore.spawn
-  saltcore setspawn:
+  saltcore-setspawn:
     description: Set spawn location to player location.
-    aliases: [ sc setspawn, salt setspawn ]
+    aliases: [ sc-setspawn, salt-setspawn ]
     permission: saltcore.setspawn
-  saltcore reload:
+  saltcore-reload:
     description: Reload configuration file.
-    aliases: [ sc reload, salt reload ]
+    aliases: [ sc-reload, salt-reload ]
     permission: saltcore.reload
   rtp:
     description: Teleport the command sender to a random location


### PR DESCRIPTION
The plugin.yml does not support directly adding subcommands (e.g. "/saltcore setspawn" and "/saltcore reload"). You have two options:

1. Make it a single command with a dash in between ("/saltcore-setspawn" and "/saltcore-reload"). That is what this pull request does to make a quick fix, but you can always change later for option 2 if you want to have real subcommands. 

2. Create a base command /saltcore, and use the String[] args within your onCommand method to check the first argument ("setspawn" or "reload"). From there, check permissions with sender.hasPermission(), and then do whatever the subcommand should do. This is usually the option that plugins choose, but I'll let you decide what you want for it. 